### PR TITLE
To string for primitive string class

### DIFF
--- a/src/compiler/java/runtime/system/javalang/PrimitiveStringClass.ts
+++ b/src/compiler/java/runtime/system/javalang/PrimitiveStringClass.ts
@@ -36,9 +36,9 @@ export class PrimitiveStringClass extends ObjectClass {
         {type: "method", signature: "public final boolean matches(string regex)", template: "(§1.match(new RegExp(§2, 'g')) != null)", constantFoldingFunction: (obj, target) => (obj.match(new RegExp(target, 'g')) != null)},
         {type: "method", signature: "public final string replaceFirst(string regex, string replacement)", template: "§1.replace(new RegExp(§2, ''), () => §3)", constantFoldingFunction: (obj, target, replacement) => obj.replace(new RegExp(target, ''), replacement)},
         {type: "method", signature: "public final string[] split(string regex)", template: `§1.split(new RegExp(§2, ''))` /*.map((s) => new ${Helpers.classes}['String'](s))` */ },
-        { type: "method", signature: "public final int hashCode()", template: `Array.from(§1).reduce((s, c) => Math.imul(31, s) + c.charCodeAt(0) | 0, 0)`, constantFoldingFunction: (obj: string) => {return Array.from(obj).reduce((s: number, c) => Math.imul(31, s) + c.charCodeAt(0) | 0, 0)} },
-        { type: "method", signature: "public final char[] toCharArray()", template: `Array.from(§1)`, constantFoldingFunction: (obj: string) => {return Array.from(obj)} },
-
+        {type: "method", signature: "public final int hashCode()", template: `Array.from(§1).reduce((s, c) => Math.imul(31, s) + c.charCodeAt(0) | 0, 0)`, constantFoldingFunction: (obj: string) => {return Array.from(obj).reduce((s: number, c) => Math.imul(31, s) + c.charCodeAt(0) | 0, 0)}},
+        {type: "method", signature: "public final char[] toCharArray()", template: `Array.from(§1)`, constantFoldingFunction: (obj: string) => {return Array.from(obj)}},
+        {type: "method", signature: "public final string toString()", template: `§1`, constantFoldingFunction: (obj: string) => obj}
     ]
 
     static type: NonPrimitiveType;


### PR DESCRIPTION
Solves #4 .

It took quite a while to understand that in the declaration `public final string toString()`, the return type must be lowercase `string`.