### PR TITLE
JavaScript

### DIFF
--- a/src/compiler/java/runtime/system/SystemModule.ts
+++ b/src/compiler/java/runtime/system/SystemModule.ts
@@ -68,6 +68,7 @@ import { ConsoleClass } from "./additional/ConsoleClass.ts";
 import { FilesClass } from "./additional/FilesClass.ts";
 import { GamepadClass } from "./additional/GamepadClass.ts";
 import { InputClass } from "./additional/InputClass.ts";
+import { JavaScriptClass } from "./additional/JavaScriptClass.ts";
 import { KeyClass } from "./additional/KeyClass.ts";
 import { KeyListenerInterface } from "./additional/KeyListenerInterface.ts";
 import { MathToolsClass } from "./additional/MathToolsClass.ts";
@@ -246,6 +247,8 @@ export class SystemModule extends JavaLibraryModule {
             // Robot
             RobotClass, RobotWorldClass,
 
+            // JavaScript
+            JavaScriptClass
         );
 
 

--- a/src/compiler/java/runtime/system/additional/JavaScriptClass.ts
+++ b/src/compiler/java/runtime/system/additional/JavaScriptClass.ts
@@ -1,0 +1,52 @@
+import type { LibraryDeclarations } from "../../../module/libraries/DeclareType";
+import { BigIntegerClass } from "../javalang/BigIntegerClass";
+import { StringClass } from "../javalang/ObjectClassStringClass";
+import type { ObjectClass } from "../javalang/ObjectClassStringClass";
+import { BooleanClass } from "../primitiveTypes/wrappers/BooleanClass";
+import { DoubleClass } from "../primitiveTypes/wrappers/DoubleClass";
+
+
+export class JavaScriptClass {
+    static __javaDeclarations: LibraryDeclarations = [
+        { type: "declaration", signature: "final class JavaScript" },
+        { type: "method", signature: "static Object exec(string functionBody, Object... args)", native: JavaScriptClass.prototype.exec }
+    ];
+
+    exec(functionBody: string, args: ObjectClass[]): ObjectClass {
+        const unwrappedArgs = args.map(JavaScriptClass.#unwrapValue)
+
+        const jsFunction = new Function('args', functionBody)
+
+        const result = jsFunction(unwrappedArgs)
+
+        return JavaScriptClass.#wrapValue(result)
+    }
+
+    static #unwrapValue(o: ObjectClass): any {
+        // let's hope we have a number, boolean, bigint or string, which have a value property
+        // and can be converted to JavaScript primitive types:
+        return (o as any).value
+            // otherwise: directly pass object
+            ?? o
+    }
+
+    static #wrapValue(o: any) {
+        switch (typeof o) {
+            case 'boolean':
+                return new BooleanClass(o)
+            case 'number':
+                return new DoubleClass(o)
+            case 'bigint':
+                return new BigIntegerClass(o)
+            case 'string':
+                return new StringClass(o)
+            case 'object':
+                if (['Boolean', 'Number', 'BigInt', 'String'].includes(o.constructor.name)) {
+                    // JavaScript wrapper type: convert to JavaScript primitive type.
+                    return JavaScriptClass.#wrapValue(o.valueOf())
+                } else {
+                    return o
+                }
+        }
+    }
+}


### PR DESCRIPTION
A first attempt to allow JavaScript inside the LearnJ language.

With parameter passing and returning a value. Primitive data types (and their boxed variants) get converted to their corresponding JavaScript data types (and vice versa for the return value).

Example:

```java
Object o = JavaScript.exec(
   "alert(args[3]); setTimeout(() => alert(args[1].x), 3000); return args[2] / 2",
   new BigInteger(32),
   new Vector2(2, 4),
   Integer.valueOf(42),
   "meh"
   );

println(o);
```

Notes:

* The parameters can be accessed as `args` array.
* I wanted to call `Vector2.toString()` on the JavaScript side. Unfortunately, the method looks like that on the JavaScript side: 
  `_mj$toString$String$(t: Thread, callback: CallbackFunction)`
  That's a pity. Additionally, we don't have a Thread parameter.

* Beware! Introducing a feature like this to the public may result in leaking online-ide internal APIs to the public. This can quickly result in the online-ide not being able to evolve anymore (i. e. changing any internal APIs) because the public audience has programmed against that. Examples already mentioned are: The Thread class, the current crude method names.