### PR TITLE
move-instruction-pointer

### DIFF
--- a/src/client/main/gui/Editor.ts
+++ b/src/client/main/gui/Editor.ts
@@ -225,6 +225,31 @@ export class Editor {
 
         JavaAddEditorShortcuts.addActions(this.editor);
 
+        this.editor.addAction({
+            id: 'Debugger Goto',
+            label: 'interpreter goto',
+
+            // An optional array of keybindings for the action.
+            keybindings: [
+                monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyK],
+
+            // A precondition for this action.
+            precondition: undefined,
+
+            // A rule to evaluate on top of the precondition in order to dispatch the keybindings.
+            keybindingContext: undefined,
+
+            contextMenuGroupId: 'navigation',
+
+            contextMenuOrder: 1.5,
+
+            // Method that will be executed when the action is triggered.
+            // @param editor The editor instance is passed in as a convenience
+            run: (ed) => {
+                this.main.getActionManager().trigger("interpreter.goto", this.editor.getSelection().startLineNumber)
+            }
+        });
+
         // console.log(this.editor.getSupportedActions().map(a => a.id));
 
         return this.editor;

--- a/src/compiler/common/interpreter/ActionManager.ts
+++ b/src/compiler/common/interpreter/ActionManager.ts
@@ -3,7 +3,7 @@ import { SoundTools } from '../../../tools/SoundTools';
 
 export type ButtonToggler = (state: boolean) => void;
 
-export type Action = (name: string, buttonToggler?: ButtonToggler, pressed_key?: string) => void;
+export type Action = (name: string, buttonToggler?: ButtonToggler, pressed_key?: string, ...args: any[]) => void;
 
 export type ActionEntry = {
     text?: string,
@@ -40,10 +40,10 @@ export class ActionManager {
 
     }
 
-    trigger(actionIdentifier: string) {
+    trigger(actionIdentifier: string, ...args: any[]) {
         let ae = this.actions[actionIdentifier];
         if(ae != null){
-            ae.action(actionIdentifier, undefined, "");
+            ae.action(actionIdentifier, undefined, "", ...args);
         }
     }
 


### PR DESCRIPTION
One step towards #15:

Move the instuction pointer. Proof of concept.

Type the following program:
```java
int i = 42;
i++;
println(i);
```

Put a breakpoint in line 3. Execute. When the program halts, Right-click on line 2 and select "Interpreter Goto". Continue executing the program. It will spit out 44 instead of 43.

@martin-pabst What do you think?