### PR TITLE
WIP: hot code replacement

### DIFF
--- a/src/client/main/gui/Editor.ts
+++ b/src/client/main/gui/Editor.ts
@@ -7,6 +7,7 @@ import { Main } from "../Main.ts";
 import { MainBase } from "../MainBase.ts";
 import { FileTypeManager } from "../../../compiler/common/module/FileTypeManager.ts";
 import * as monaco from 'monaco-editor'
+import { hotCodeRecordEdits } from '../../../compiler/common/interpreter/HotCodeReplacement.ts';
 
 export type HistoryEntry = {
     file_id: number,
@@ -106,8 +107,10 @@ export class Editor {
         this.editor.onDidChangeModelContent((e: monaco.editor.IModelContentChangedEvent) => {
             let state = this.main.getInterpreter().scheduler.state;
             if ([SchedulerState.stopped, SchedulerState.error, SchedulerState.not_initialized].indexOf(state) < 0) {
-                this.main.getActionManager().trigger("interpreter.stop");
+//                this.main.getActionManager().trigger("interpreter.stop");
             }
+
+            hotCodeRecordEdits(this, e)
         })
 
         let that: Editor = this;

--- a/src/compiler/common/BreakpointManager.ts
+++ b/src/compiler/common/BreakpointManager.ts
@@ -43,7 +43,7 @@ export class BreakpointManager {
     attachToInterpreter(interpreter: Interpreter){
 
         interpreter.eventManager.on("resetRuntime", () => {
-            this.#writeAllBreakpointsIntoPrograms();
+            this.writeAllBreakpointsIntoPrograms();
         })
 
     }
@@ -166,7 +166,7 @@ export class BreakpointManager {
         return breakpointInfoForModule;
     }
 
-    #writeAllBreakpointsIntoPrograms() {
+    writeAllBreakpointsIntoPrograms() {
         let executable = this.main.getInterpreter().executable;
         if (!executable) return;
 

--- a/src/compiler/common/Executable.ts
+++ b/src/compiler/common/Executable.ts
@@ -37,7 +37,7 @@ export class Executable {
 
         this.findMainModule(false, lastOpenedFile, currentlyOpenedModule);
 
-        this.setupStaticInitializationSequence(globalErrors);
+        this.#setupStaticInitializationSequence(globalErrors);
 
     }
 
@@ -49,7 +49,7 @@ export class Executable {
         }
     }
 
-    setupStaticInitializationSequence(errors: Error[]) {
+    #setupStaticInitializationSequence(errors: Error[]) {
         let classesToInitialize: NonPrimitiveType[] = [];
 
         this.staticInitializationSequence = [];

--- a/src/compiler/common/interpreter/HotCodeReplacement.ts
+++ b/src/compiler/common/interpreter/HotCodeReplacement.ts
@@ -1,0 +1,274 @@
+import { Editor } from "../../../client/main/gui/Editor";
+import { Executable } from "../Executable";
+import { Interpreter } from "./Interpreter";
+import type * as monaco from 'monaco-editor'
+import { SchedulerState } from "./SchedulerState";
+import { Program } from "./Program";
+
+
+// for every currently running method: the amount of editor lines the instruction pointer must be moved
+let lineAdj: Record<string, {
+    // addLines: number,
+    changesBefore: boolean,
+    changesAfter: boolean
+}> = {}
+
+
+export function hotCodeRecordEdits(ed: Editor, ev: monaco.editor.IModelContentChangedEvent) {
+    const i = ed.main.getInterpreter()
+
+    if (i.scheduler.state !== SchedulerState.paused) {
+        lineAdj = {}
+        return
+    }
+
+    const module = ed.main.getCurrentWorkspace()?.getCurrentlyEditedModule()
+    ;
+    [
+        ...i.scheduler.runningThreads,
+        ...i.scheduler.suspendedThreads,
+        ...i.scheduler.storedThreads ?? []
+    ]
+    .flatMap(t => t.programStack)
+    .filter(ps => ps.program.module === module)
+    .forEach(ps => {
+        // TODO getter dafür
+        const currStepR = ps.currentStepList[ps.stepIndex].range
+
+        const la = lineAdj[ps.program.methodIdentifierWithClass] ??= {
+            // addLines: 0,
+            changesBefore: false,
+            changesAfter: false
+        }
+
+        ev.changes.forEach(c => {
+            // With "instruction pointer" I mean the point BEFORE the next statement, i. e. currStepR.start{Line, Column}.
+
+            // change is before instruction pointer: take care:
+            if (c.range.endLineNumber < currStepR.startLineNumber
+                || c.range.endLineNumber === currStepR.startLineNumber && c.range.endColumn <= currStepR.startColumn
+            ) {
+                la.changesBefore = true
+
+                // const adj = (c.text.match(/\n/g) ?? []).length // count LFs in newly inserted text
+                //     - (c.range.endLineNumber - c.range.startLineNumber)
+
+                // if (adj !== 0) {
+                //     lineAdj[ps.program.methodIdentifierWithClass].addLines += adj
+                // }
+                return
+            }
+
+            // change is after instruction pointer: ignore.
+            if (c.range.startLineNumber > currStepR.startLineNumber
+                || c.range.startLineNumber === currStepR.startLineNumber && c.range.startColumn >= currStepR.startColumn
+            ) {
+                la.changesAfter = true
+                return
+            }
+
+            const res = prompt('HotCodeReplacement: Programm wird zurückgesetzt. Fortfahren (j/n)?', 'j')
+            switch (res) {
+                case 'j':
+                    i.setState(SchedulerState.stopped)
+                    break;
+                case 'n':
+                    ed.editor.trigger('ev_src_hcr', 'undo', undefined)
+                    break;
+                default:
+                    throw new Error()
+            }
+        })
+    })
+}
+
+function _throw(msg: string): never {
+    throw new Error(msg)
+}
+
+export function hotCodeReplaceLookupProgram(e: Executable, methodIdentifierWithClass): Program {
+    return e.moduleManager.modules
+        .flatMap(m => m.programsToCompileToFunctions)
+        .find(p => p.methodIdentifierWithClass === methodIdentifierWithClass)
+        ?? _throw('Program not found.')
+}
+
+export function hotCodeCompileAndReplace(i: Interpreter, e: Executable) {
+    e.compileToJavascript()
+    if (!e.isCompiledToJavascript) {
+        return
+    }
+
+    // TODO create a method scheduler.getAllThreads ?
+    [
+        ...i.scheduler.runningThreads,
+        ...i.scheduler.suspendedThreads,
+        ...i.scheduler.storedThreads ?? []
+    ].forEach(t => {
+        let newStackBase = 0
+
+        t.programStack.forEach(ps => {
+
+            /**
+             * Save data about old compilation
+             */
+            // const step = ps.currentStepList[ps.stepIndex]
+            // const oldLineNo = step.range.startLineNumber
+            //
+            // const indexInOldStepsWithSameLineNo = ps.currentStepList
+            //     .filter(s => s.range.startLineNumber === oldLineNo)
+            //     .findIndex(s => s === step)
+
+
+            /*
+             * Replace code in running thread
+             */
+            const methodIdentifierWithClass = ps.program.methodIdentifierWithClass // TODO Program should have class and method reference
+
+            const newProgram = hotCodeReplaceLookupProgram(e, methodIdentifierWithClass)
+
+            if (!newProgram) {
+                throw new Error(`HotCodeReplacement: Method ${methodIdentifierWithClass} not found any more.`)
+            }
+
+            const oldProgram = ps.program
+            // const oldStepCode = ps.currentStepList[ps.stepIndex].codeAsString
+            ps.program = newProgram
+            ps.currentStepList = ps.program.stepsSingle
+
+
+            /*
+             * Adjust stackframe using symbol table
+             */
+            if (oldProgram.numberOfParameters !== newProgram.numberOfParameters) {
+                throw new Error('Unsupported: Number of params changed.')
+            }
+            if (oldProgram.numberOfThisObjects !== newProgram.numberOfThisObjects) {
+                throw new Error('Unsupported: Number of this objects changed.')
+            }
+
+            const [oldSymbols, newSymbols] = [oldProgram, newProgram].map(p =>
+                Object.fromEntries(Object.entries(p.symbolTable.stackframe.positionToSymbolMap)
+                    .map(([pos, s]) => [s.identifier, pos]))
+            )
+
+            ps.stackBase = newStackBase
+
+            const newLocalVarsStackFrame = Array(newProgram.numberOfLocalVariables)
+            Object.entries(newProgram.symbolTable.stackframe.positionToSymbolMap)
+                .filter(([pos, _s]) => parseInt(pos) >= newProgram.numberOfThisObjects + newProgram.numberOfParameters)
+                .forEach(([pos, s]) => {
+                    newLocalVarsStackFrame[parseInt(pos) - newProgram.numberOfParameters - newProgram.numberOfThisObjects]
+                        = t.s[ps.stackBase + parseInt(oldSymbols[s.identifier])] // really? Ohne numberOfThisObjects hier?
+                })
+
+            t.s.splice(ps.stackBase + newProgram.numberOfThisObjects + newProgram.numberOfParameters, oldProgram.numberOfLocalVariables, ...newLocalVarsStackFrame)
+
+            // ^^^ TODO das -1 - hängt das mit calling convention zusammen?
+
+            // calculate stackBase for the next stackframe:
+            newStackBase = ps.stackBase + newProgram.numberOfThisObjects + newProgram.numberOfParameters + newProgram.numberOfLocalVariables
+
+
+            /*
+             * Adjust stepIndex.
+             */
+            const la = lineAdj[ps.program.methodIdentifierWithClass]
+            if (la) {
+                delete lineAdj[ps.program.methodIdentifierWithClass]
+
+                if (la.changesAfter && la.changesBefore) {
+                    throw new Error('Unsupported: Modifications both before and after the current instruction pointer.')
+                }
+
+                if (la.changesBefore && !la.changesAfter) {
+                    // DER Trick: Es gibt zwar vielleicht neue Steps VOR stepIndex, aber nicht danach.
+                    // Der Abstand program.length - stepIndex soll also konstant bleiben:
+                    ps.stepIndex += newProgram.stepsSingle.length - oldProgram.stepsSingle.length
+                }
+            }
+
+            // if (lineAdj[ps.program.methodIdentifierWithClass].addLines) {
+            //     const newLineNo = oldLineNo + lineAdj[ps.program.methodIdentifierWithClass].addLines
+
+            //     const newStepIndex = ps.currentStepList
+            //         .findIndex(s => s.range.startLineNumber === newLineNo)
+            //         + indexInOldStepsWithSameLineNo
+
+            //     if (newStepIndex === -1 || ps.currentStepList[newStepIndex].range.startLineNumber !== newLineNo) {
+            //         throw new Error('Invariant failed.')
+            //     }
+
+            //     ps.stepIndex = newStepIndex
+            //     delete lineAdj[ps.program.methodIdentifierWithClass]
+            // }
+
+            // while (true) {
+            //     const newStepCode = ps.currentStepList[ps.stepIndex].codeAsString
+            //     const [osc, nsc] = [oldStepCode, newStepCode].map(c => c.match(/^(.*)\nreturn [0-9]+;$/)[1])
+
+            //     if (osc === nsc) {
+            //         break
+            //     }
+
+            //     ps.stepIndex++
+
+            //     if (ps.stepIndex >= ps.currentStepList.length) {
+            //         throw new Error('not found')
+            //     }
+            // }
+            // if (nsc !== osc) {
+            //     throw new Error('Did not expect a change of the next statement, i. e. the yellow line.')
+            // }
+        })
+
+        t.classes = e.classObjectRegistry
+    })
+
+    i.breakpointManager.writeAllBreakpointsIntoPrograms()
+
+    i.scheduler.classObjectRegistry = e.classObjectRegistry
+}
+
+
+// Bug?: Program can run empty on compile error
+// Problem: green vs yellow line
+
+// Kompilieren on Errors !?
+
+// Name mangling for methodIdentifierWithClass ...
+
+// TODO worker threads increase
+
+
+/*
+
+class Person2 {
+   public String fname;
+   public String vname;
+
+   Person2(String f, String v) {
+      fname = f;
+      vname = v;
+   }
+
+   public String toString() {
+      return fname + ", " + vname;
+   }
+}
+
+void f(int  ii) {
+   int  d = 58;
+   int  e = 59;
+   print ln("seppX:" + ii + " " + d);
+   print ln(new Person2("H", "S"));
+}
+
+int  a = 42;
+int  b = 43;
+for (int  i = 2; i < 5; i++) {
+   print ln("i : " + i);
+   f(i);
+}
+
+*/

--- a/src/compiler/common/interpreter/Program.ts
+++ b/src/compiler/common/interpreter/Program.ts
@@ -39,8 +39,9 @@ export class Step {
     }
 
     setBreakpoint() {
+        if (this.originalRun) return; // breakpoint already set
 
-        let breakpointRunFunction = (thread: Thread, stack: any[], stackBase: number): number => {
+        const breakpointRunFunction = (thread: Thread, stack: any[], stackBase: number): number => {
             if (thread.haltAtNextBreakpoint) {
                 thread.state = ThreadState.stoppedAtBreakpoint;
                 thread.haltAtNextBreakpoint = false;
@@ -51,7 +52,6 @@ export class Step {
             }
         }
 
-        if (this.originalRun) return; // breakpoint already set
         this.originalRun = this.run;
         this.run = breakpointRunFunction;
     }

--- a/src/compiler/common/interpreter/Thread.ts
+++ b/src/compiler/common/interpreter/Thread.ts
@@ -13,6 +13,7 @@ import { ArrayToStringCaster, TextContainer } from "./ArrayToStringCaster.ts";
 import { CallbackParameter } from "./CallbackParameter.ts";
 import { CatchBlockInfo, Exception, ExceptionInfo } from "./ExceptionInfo.ts";
 import { ExceptionPrinter } from "./ExceptionPrinter.ts";
+import { hotCodeReplaceLookupProgram } from "./HotCodeReplacement.ts";
 import { Program, Step } from "./Program";
 import { ProgramState } from "./ProgramState.ts";
 import { Scheduler } from "./Scheduler";
@@ -458,12 +459,19 @@ export class Thread {
 
     }
 
+    pushMethod(methodIdentifierWithClass, callback: CallbackFunction, ...thisObjectsAndparameters) {
+        const program = hotCodeReplaceLookupProgram(this.scheduler.interpreter.executable, methodIdentifierWithClass)
+        this.s.push(...thisObjectsAndparameters);
+        this.pushProgram(program, callback)
+    }
 
     /**
      * call a java method which is executed by this thread
      * @param program
      */
     pushProgram(program: Program, callback?: CallbackFunction) {
+        // program = hotCodeReplaceLookupProgram(this.scheduler.interpreter.executable, program.methodIdentifierWithClass)
+
         // Object creation is faster than Object.assign, see
         // https://measurethat.net/Benchmarks/Show/18401/0/objectassign-vs-creating-new-objects3
         let state: ProgramState = {

--- a/src/compiler/java/JavaCompiler.ts
+++ b/src/compiler/java/JavaCompiler.ts
@@ -82,7 +82,7 @@ export class JavaCompiler implements Compiler {
 
         // if we're not in test mode:
         if (this.main) {
-            if (this.main.getInterpreter().isRunningOrPaused()) return;
+//FJFTODO            if (this.main.getInterpreter().isRunningOrPaused()) return;
             let currentWorkspace = this.main?.getCurrentWorkspace();
             if (!currentWorkspace) return;
             this.moduleManager.workspace = currentWorkspace;

--- a/src/compiler/java/codegenerator/TermCodeGenerator.ts
+++ b/src/compiler/java/codegenerator/TermCodeGenerator.ts
@@ -1218,14 +1218,21 @@ export abstract class TermCodeGenerator extends BinopCastCodeGenerator {
             }
         }
 
+
+
+
+
         if (callingConvention == "java") {
             objectTemplate += `${StepParams.thread}` +
                 (method.isStatic ? '' : `, undefined`) +     // non-static methods have callback-function as second parameter
                 (parameterValueSnippet.length > 0 ? ", " : "");
         }
 
+        objectTemplate = `__t.pushMethod("${method.classEnumInterface.identifier}.${method.identifier}", undefined, §1, `
+
         let i = 2;
         objectTemplate += parameterValueSnippet.map(_p => "§" + (i++)).join(", ") + ")";
+
 
         parameterValueSnippet.unshift(objectSnippet);
 

--- a/src/compiler/java/module/JavaCompiledModule.ts
+++ b/src/compiler/java/module/JavaCompiledModule.ts
@@ -233,6 +233,7 @@ export class JavaCompiledModule extends JavaBaseModule {
         let THIS = mainRuntimeClass;
 
         methodStub.call(THIS, thread, thread.s);
+        // thread.pushMethod(`${mainMethod.classEnumInterface.identifier}.${mainMethod.identifier}`, undefined, mainRuntimeClass)
 
         return true;
 

--- a/src/compiler/java/parser/Parser.ts
+++ b/src/compiler/java/parser/Parser.ts
@@ -59,8 +59,9 @@ export class Parser extends StatementParser {
             path: ""
         }
 
+        // TODO hier besserem deterministischen Klassenneman verwenden, counter stilllegen.
         this.javaCompiledModule.mainClass = this.nodeFactory.buildClassNode(this.nodeFactory.buildNodeWithModifiers(EmptyRange.instance),
-        { tt: TokenType.identifier, value: "$MainClass" + (Parser.mainClassCounter++), range: EmptyRange.instance }, this.javaCompiledModule.ast!, [], this.javaCompiledModule);
+        { tt: TokenType.identifier, value: `$MainClass${this.javaCompiledModule.file.name}`, range: EmptyRange.instance }, this.javaCompiledModule.ast!, [], this.javaCompiledModule);
         this.javaCompiledModule.mainClass.range = globalRange;
         this.javaCompiledModule.mainClass.isMainClass = true;
 


### PR DESCRIPTION
WIP: hot code replacement

A first try.

### You can:
* Edit code either before or after the current instruction pointer
* Add or remove local variables

### You can't:
* Edit both before and after the current instruction pointer at the same instant (for example, with a global replace)
* Concerning methods on the stack:
  * Add or remove parameters
  * modify function name

### What approx. happens is:
* recompile
* replace classObjectRegistry
* for each thread, for each program in thread.programStack:
  * replace stepList
  * re-apply breakpoints
  * re-calc stepIndex
  * re-calc local variable alignment in thread.s

### Modifications needed in the core program:
Currently, compiled code calls methods using a closure. This closure is bound to the previous compile process, so that won't work.
So I modified the code generation and the runtime API (Thread.pushMethod) to use a lookup table to find methods.
This is currently rudimentary and inperformantly implemented (i. e. we need a hashmap to lookup methods).
