### PR TITLE
prevent predefined colors from being initialized multiple times

### DIFF
--- a/src/client/help/JavaSyntaxAPIPrinter.ts
+++ b/src/client/help/JavaSyntaxAPIPrinter.ts
@@ -1,26 +1,18 @@
 import { TokenType, TokenTypeReadable } from "../../compiler/java/TokenType";
 import { GenericTypeParameter } from "../../compiler/java/types/GenericTypeParameter";
-import { IJavaClass, JavaClass } from "../../compiler/java/types/JavaClass";
+import { JavaClass } from "../../compiler/java/types/JavaClass";
 import { JavaEnum } from "../../compiler/java/types/JavaEnum";
 import { JavaField } from "../../compiler/java/types/JavaField";
-import { IJavaInterface, JavaInterface } from "../../compiler/java/types/JavaInterface";
+import { JavaInterface } from "../../compiler/java/types/JavaInterface";
 import { GenericMethod, JavaMethod } from "../../compiler/java/types/JavaMethod";
 import { Visibility } from "../../compiler/java/types/Visibility.ts";
 import { APIPrinter } from "./APIPrinter";
-
-type classEnumInterface = "class" | "enum" | "interface";
 
 export class JavaSyntaxAPIPrinter extends APIPrinter {
 
     indentation: string = "   ";
 
     printClassEnumInterface(cei: JavaClass | JavaEnum | JavaInterface): string {
-        let type: classEnumInterface;
-
-        if (cei instanceof JavaClass) type = "class";
-        if (cei instanceof JavaEnum) type = "enum";
-        if (cei instanceof JavaInterface) type = "interface";
-
         let s: string = ""; 
             s += this.toJavaDocComment(cei.documentation, "");
             s += cei.getDeclaration();

--- a/src/compiler/java/runtime/graphics/ColorClass.ts
+++ b/src/compiler/java/runtime/graphics/ColorClass.ts
@@ -41,7 +41,10 @@ export class ColorClass extends ObjectClass {
 
     alpha: number = 1.0;
 
+    static predefinedColorsInitialized = false;
     static _initPredefinedColors(){
+        if(ColorClass.predefinedColorsInitialized) return;
+        ColorClass.predefinedColorsInitialized = true;
 
         for (let colorName in ColorHelper.predefinedColors) {
 


### PR DESCRIPTION
_initPredefinedColors() is called every time a module is initialized. this caused the predefined color constants to be created multiple times. it was most noticeable in the API export where each constant was printed twice.

also removed a few lines from the API printer which were unused.