### PR TITLE
Implement Dependency Injection support with @Instance and @Inject ann…

### DIFF
--- a/src/compiler/common/Executable.ts
+++ b/src/compiler/common/Executable.ts
@@ -33,6 +33,7 @@ export class Executable {
         public exceptionTree: ExceptionTree
     ) {
         this.#setupStaticInitializationSequence(globalErrors);
+        this.#setupDIInitializationSequence();
     }
 
     compileToJavascript() {
@@ -101,6 +102,64 @@ export class Executable {
             const errorWithId = JCM.cyclicReferencesAmongStaticVariables(classesToInitialize.map(c => c.identifier).join(", "));
             errors.push({ message: errorWithId.message, id: errorWithId.id, level: "error", range: EmptyRange.instance });
         }
+    }
+
+    #setupDIInitializationSequence() {
+        const diTypes: NonPrimitiveType[] = [];
+
+        for (const module of this.moduleManager.modules.filter(m => !m.hasErrors())) {
+            if (!module.ast) continue;
+            for (const cdef of module.ast.innerTypes) {
+                const type = cdef.resolvedType;
+                if (type && type.diInitializer && type.diInitializer.stepsSingle.length > 0) {
+                    diTypes.push(type);
+                }
+            }
+        }
+
+        // topological sort based on @Inject dependencies among @Instance classes
+        const sorted = this.#topologicalSortDITypes(diTypes);
+
+        for (const type of sorted) {
+            this.staticInitializationSequence.push({
+                klass: type.runtimeClass!,
+                program: type.diInitializer!
+            });
+        }
+    }
+
+    #topologicalSortDITypes(diTypes: NonPrimitiveType[]): NonPrimitiveType[] {
+        const nameToType = new Map<string, NonPrimitiveType>();
+        for (const type of diTypes) {
+            if (type.diInstanceName) nameToType.set(type.diInstanceName, type);
+        }
+
+        const sorted: NonPrimitiveType[] = [];
+        const visited = new Set<string>();
+
+        const visit = (type: NonPrimitiveType) => {
+            if (!type.diInstanceName || visited.has(type.diInstanceName)) return;
+            visited.add(type.diInstanceName);
+
+            const module = this.moduleManager.modules.find(m => m.types.includes(type));
+            if (module?.ast) {
+                const cdef = module.ast.innerTypes.find(c => c.resolvedType === type);
+                if (cdef) {
+                    for (const fieldOrInit of (cdef as any).fieldsOrInstanceInitializers ?? []) {
+                        const injectAnnotation = fieldOrInit.annotations?.find((a: any) => a.identifier === "Inject");
+                        if (injectAnnotation?.parameter) {
+                            const dep = nameToType.get(injectAnnotation.parameter);
+                            if (dep) visit(dep);
+                        }
+                    }
+                }
+            }
+
+            sorted.push(type);
+        };
+
+        for (const type of diTypes) visit(type);
+        return sorted;
     }
 
     hasTests(): boolean {

--- a/src/compiler/java/TypeResolver/DIValidator.ts
+++ b/src/compiler/java/TypeResolver/DIValidator.ts
@@ -1,0 +1,183 @@
+import { ErrorLevel } from "../../common/Error";
+import { IRange } from "../../common/range/Range";
+import { ErrormessageWithId } from "../../../tools/language/LanguageManager.ts";
+import { TokenType } from "../TokenType";
+import { JavaBaseModule } from "../module/JavaBaseModule";
+import { ASTClassDefinitionNode, ASTEnumDefinitionNode, ASTFieldDeclarationNode, ASTInterfaceDefinitionNode } from "../parser/AST";
+import { JavaClass } from "../types/JavaClass";
+import { JCM } from "../language/JavaCompilerMessages.ts";
+
+type PushErrorFn = (msg: ErrormessageWithId, range: IRange, module: JavaBaseModule, level?: ErrorLevel) => void;
+
+export class DIValidator {
+
+    static validate(
+        classDeclarationNodes: ASTClassDefinitionNode[],
+        interfaceDeclarationNodes: ASTInterfaceDefinitionNode[],
+        enumDeclarationNodes: ASTEnumDefinitionNode[],
+        pushError: PushErrorFn
+    ): Map<string, ASTClassDefinitionNode> {
+
+        const instanceMap = new Map<string, ASTClassDefinitionNode>();
+
+        DIValidator.validateInstanceAnnotations(classDeclarationNodes, interfaceDeclarationNodes, enumDeclarationNodes, pushError, instanceMap);
+
+        DIValidator.validateInjectAnnotations(classDeclarationNodes, pushError, instanceMap);
+
+        DIValidator.detectCircularDependencies(classDeclarationNodes, pushError, instanceMap);
+
+        return instanceMap;
+    }
+
+    private static validateInstanceAnnotations(
+        classDeclarationNodes: ASTClassDefinitionNode[],
+        interfaceDeclarationNodes: ASTInterfaceDefinitionNode[],
+        enumDeclarationNodes: ASTEnumDefinitionNode[],
+        pushError: PushErrorFn,
+        instanceMap: Map<string, ASTClassDefinitionNode>
+    ) {
+        for (const ifaceNode of interfaceDeclarationNodes) {
+            const annotation = ifaceNode.annotations?.find(a => a.identifier === "Instance");
+            if (!annotation) continue;
+            pushError(JCM.diInstanceOnNonClass(), ifaceNode.range, ifaceNode.module);
+        }
+
+        for (const enumNode of enumDeclarationNodes) {
+            const annotation = enumNode.annotations?.find(a => a.identifier === "Instance");
+            if (!annotation) continue;
+            pushError(JCM.diInstanceOnNonClass(), enumNode.range, enumNode.module);
+        }
+
+        for (const classNode of classDeclarationNodes) {
+            const annotation = classNode.annotations?.find(a => a.identifier === "Instance");
+            if (!annotation) continue;
+
+            if (!annotation.parameter) {
+                pushError(JCM.diAnnotationRequiresParameter("Instance"), annotation.range, classNode.module);
+                continue;
+            }
+
+            if (classNode.isMainClass) {
+                pushError(JCM.diInstanceOnMainClass(), annotation.range, classNode.module);
+                continue;
+            }
+
+            const resolvedType = classNode.resolvedType as JavaClass | undefined;
+
+            if (resolvedType?.isAbstract()) {
+                pushError(JCM.diInstanceOnAbstractClass(classNode.identifier), annotation.range, classNode.module);
+                continue;
+            }
+
+            const name = annotation.parameter;
+            if (instanceMap.has(name)) {
+                const firstNode = instanceMap.get(name)!;
+                pushError(JCM.diDuplicateInstanceName(name), annotation.range, classNode.module);
+                pushError(JCM.diDuplicateInstanceName(name), firstNode.annotations!.find(a => a.identifier === "Instance")!.range, firstNode.module);
+                continue;
+            }
+
+            if (resolvedType) {
+                const hasDefaultCtor = resolvedType.methods.some(m => m.isConstructor && m.parameters.length === 0)
+                    || !resolvedType.methods.some(m => m.isConstructor);
+                if (!hasDefaultCtor) {
+                    pushError(JCM.diInstanceNoDefaultConstructor(classNode.identifier), annotation.range, classNode.module);
+                    continue;
+                }
+            }
+
+            instanceMap.set(name, classNode);
+        }
+    }
+
+    private static validateInjectAnnotations(
+        classDeclarationNodes: ASTClassDefinitionNode[],
+        pushError: PushErrorFn,
+        instanceMap: Map<string, ASTClassDefinitionNode>
+    ) {
+        for (const classNode of classDeclarationNodes) {
+            for (const fieldOrInit of classNode.fieldsOrInstanceInitializers) {
+                if (fieldOrInit.kind !== TokenType.fieldDeclaration) continue;
+                const fieldNode = fieldOrInit as ASTFieldDeclarationNode;
+
+                const annotation = fieldNode.annotations?.find(a => a.identifier === "Inject");
+                if (!annotation) continue;
+
+                if (!annotation.parameter) {
+                    pushError(JCM.diAnnotationRequiresParameter("Inject"), annotation.range, classNode.module);
+                    continue;
+                }
+
+                if (fieldNode.isStatic) {
+                    pushError(JCM.diInjectOnStaticField(), annotation.range, classNode.module);
+                    continue;
+                }
+
+                if (!instanceMap.has(annotation.parameter)) {
+                    pushError(JCM.diInjectUnknownName(annotation.parameter), annotation.range, classNode.module);
+                }
+            }
+        }
+    }
+
+    private static detectCircularDependencies(
+        classDeclarationNodes: ASTClassDefinitionNode[],
+        pushError: PushErrorFn,
+        instanceMap: Map<string, ASTClassDefinitionNode>
+    ) {
+        const dependencyGraph = new Map<string, string[]>();
+
+        for (const [instanceName, classNode] of instanceMap) {
+            const deps: string[] = [];
+            for (const fieldOrInit of classNode.fieldsOrInstanceInitializers) {
+                if (fieldOrInit.kind !== TokenType.fieldDeclaration) continue;
+                const fieldNode = fieldOrInit as ASTFieldDeclarationNode;
+                const injectAnnotation = fieldNode.annotations?.find(a => a.identifier === "Inject");
+                if (injectAnnotation?.parameter && instanceMap.has(injectAnnotation.parameter)) {
+                    deps.push(injectAnnotation.parameter);
+                }
+            }
+            dependencyGraph.set(instanceName, deps);
+        }
+
+        const visited = new Set<string>();
+        const inStack = new Set<string>();
+
+        for (const startName of instanceMap.keys()) {
+            if (visited.has(startName)) continue;
+            const cycle = DIValidator.dfsCycleCheck(startName, dependencyGraph, visited, inStack, []);
+            if (cycle) {
+                const cycleStr = cycle.join(" -> ") + " -> " + cycle[0];
+                const classNode = instanceMap.get(cycle[0])!;
+                pushError(JCM.diCircularDependency(cycleStr), classNode.range, classNode.module);
+                return;
+            }
+        }
+    }
+
+    private static dfsCycleCheck(
+        name: string,
+        graph: Map<string, string[]>,
+        visited: Set<string>,
+        inStack: Set<string>,
+        path: string[]
+    ): string[] | undefined {
+        visited.add(name);
+        inStack.add(name);
+        path.push(name);
+
+        for (const dep of (graph.get(name) ?? [])) {
+            if (!visited.has(dep)) {
+                const cycle = DIValidator.dfsCycleCheck(dep, graph, visited, inStack, path);
+                if (cycle) return cycle;
+            } else if (inStack.has(dep)) {
+                const cycleStart = path.indexOf(dep);
+                return path.slice(cycleStart);
+            }
+        }
+
+        inStack.delete(name);
+        path.pop();
+        return undefined;
+    }
+}

--- a/src/compiler/java/TypeResolver/TypeResolver.ts
+++ b/src/compiler/java/TypeResolver/TypeResolver.ts
@@ -21,6 +21,7 @@ import { GenericMethod, JavaMethod } from "../types/JavaMethod";
 import { NonPrimitiveType } from "../types/NonPrimitiveType";
 import { JavaParameter } from "../types/JavaParameter";
 import { CycleFinder } from "./CycleFinder";
+import { DIValidator } from "./DIValidator.ts";
 import { JCM } from "../language/JavaCompilerMessages.ts";
 import { JavaCompilerStringConstants } from "../JavaCompilerStringConstants.ts";
 import { GenerateGetterAndSetterQuickfixHelper } from "../monacoproviders/quickfix/GenerateGetterAndSetterQuickfix.ts";
@@ -59,6 +60,13 @@ export class TypeResolver {
         this.buildAllMethods();
 
         this.buildRuntimeClassesAndTheirFields();
+
+        DIValidator.validate(
+            this.classDeclarationNodes,
+            this.interfaceDeclarationNodes,
+            this.enumDeclarationNodes,
+            this.pushError.bind(this)
+        );
 
         return true;
     }

--- a/src/compiler/java/codegenerator/CodeGenerator.ts
+++ b/src/compiler/java/codegenerator/CodeGenerator.ts
@@ -1,6 +1,6 @@
 import { SettingsStore } from "../../../client/settings/SettingsStore.ts";
 import { Program } from "../../common/interpreter/Program";
-import { Helpers } from "../../common/interpreter/StepFunction.ts";
+import { Helpers, StepParams } from "../../common/interpreter/StepFunction.ts";
 import { EmptyRange } from "../../common/range/Range.ts";
 import { CompilingProgressManager } from "../CompilingProgressManager.ts";
 import { TokenType } from "../TokenType";
@@ -36,6 +36,7 @@ export class CodeGenerator extends InnerClassCodeGenerator {
     async start() {
         this.module.programsToCompileToFunctions = [];
         await this.compileClassesEnumsAndInterfaces(this.module.ast);
+        this.compileDIInstanceInitializersRecursively(this.module.ast);
         // this.compileMainProgram();
     }
 
@@ -73,6 +74,8 @@ export class CodeGenerator extends InnerClassCodeGenerator {
             }
 
             this.compileInstanceFieldsAndInitializer(cdef, type as JavaClass | JavaEnum);
+
+            this.addDIInjectSnippetsToInstanceInitializer(cdef, type as JavaClass | JavaEnum);
 
             if (cdef.kind == TokenType.keywordClass) {
                 this.buildStandardConstructors(type as JavaClass);
@@ -261,6 +264,73 @@ export class CodeGenerator extends InnerClassCodeGenerator {
     }
 
 
+
+    compileDIInstanceInitializersRecursively(typeScope: TypeScope | undefined) {
+        if (!typeScope) return;
+
+        for (let cdef of typeScope.innerTypes) {
+            if (cdef.isAnonymousInnerType) continue;
+            if (cdef.kind !== TokenType.keywordClass) continue;
+
+            const type = cdef.resolvedType as JavaClass | undefined;
+            if (!type) continue;
+
+            const instanceAnnotation = cdef.annotations?.find(a => a.identifier === "Instance");
+            if (!instanceAnnotation?.parameter) {
+                this.compileDIInstanceInitializersRecursively(cdef);
+                continue;
+            }
+
+            const instanceName = instanceAnnotation.parameter;
+            const constructor = type.methods.find(m => m.isConstructor && m.parameters.length === 0);
+            if (!constructor) {
+                this.compileDIInstanceInitializersRecursively(cdef);
+                continue;
+            }
+
+            if (cdef.symbolTable) {
+                this.pushSymbolTable(cdef.symbolTable);
+            } else {
+                cdef.symbolTable = this.pushAndGetNewSymbolTable(cdef.range, false, type);
+            }
+
+            const snippets: CodeSnippet[] = [];
+            const useNative = constructor.hasImplementationWithNativeCallingConvention;
+
+            if (useNative) {
+                const ctorName = constructor.getInternalName("native");
+                snippets.push(new StringCodeSnippet(
+                    `if(!${Helpers.classes}.__di_instances) ${Helpers.classes}.__di_instances = {};\n` +
+                    `${Helpers.classes}.__di_instances["${instanceName}"] = ` +
+                    `new ${Helpers.classes}["${type.pathAndIdentifier}"]().${ctorName}();\n`
+                ));
+            } else {
+                const ctorName = constructor.getInternalName("java");
+                const callSnippet = new StringCodeSnippet(
+                    `new ${Helpers.classes}["${type.pathAndIdentifier}"]().${ctorName}(${StepParams.thread}, undefined);\n`,
+                    type.identifierRange
+                );
+                const container = new CodeSnippetContainer([callSnippet], type.identifierRange);
+                container.addNextStepMark();
+                container.finalValueIsOnStack = true;
+                snippets.push(container);
+
+                snippets.push(new StringCodeSnippet(
+                    `if(!${Helpers.classes}.__di_instances) ${Helpers.classes}.__di_instances = {};\n` +
+                    `${Helpers.classes}.__di_instances["${instanceName}"] = ` +
+                    `${StepParams.thread}.s[${StepParams.thread}.s.length - 1];\n` +
+                    `${StepParams.thread}.s.pop();\n`
+                ));
+            }
+
+            type.diInstanceName = instanceName;
+            type.diInitializer = this.buildInitializer(snippets, "diInitializer:" + instanceName);
+
+            this.popSymbolTable();
+
+            this.compileDIInstanceInitializersRecursively(cdef);
+        }
+    }
 
     buildInitializer(snippets: CodeSnippet[], identifier: string): Program {
         let program = new Program(this.module, this.currentSymbolTable, identifier);

--- a/src/compiler/java/codegenerator/InnerClassCodeGenerator.ts
+++ b/src/compiler/java/codegenerator/InnerClassCodeGenerator.ts
@@ -487,7 +487,30 @@ export class InnerClassCodeGenerator extends StatementCodeGenerator {
     }
 
     compileAnnotation(node: ASTAnnotationNode): JavaAnnotation {
-        return new JavaAnnotation(node.identifier, node.range);
+        return new JavaAnnotation(node.identifier, node.range, node.parameter);
+    }
+
+    addDIInjectSnippetsToInstanceInitializer(cdef: ASTClassDefinitionNode | ASTEnumDefinitionNode, classContext: JavaClass | JavaEnum) {
+        if (!(classContext instanceof JavaClass)) return;
+
+        for (const fieldOrInit of cdef.fieldsOrInstanceInitializers) {
+            if (fieldOrInit.kind !== TokenType.fieldDeclaration) continue;
+            if (fieldOrInit.isStatic) continue;
+
+            const injectAnnotation = fieldOrInit.annotations?.find(a => a.identifier === "Inject");
+            if (!injectAnnotation?.parameter) continue;
+
+            const field = classContext.fields.find(f => f.identifier === fieldOrInit.identifier);
+            if (!field) continue;
+
+            const instanceName = injectAnnotation.parameter;
+            const injectSnippet = new StringCodeSnippet(
+                `${Helpers.elementRelativeToStackbase(0)}.${field.getInternalName()} = ` +
+                `(${Helpers.classes}.__di_instances && ${Helpers.classes}.__di_instances["${instanceName}"]) || null;\n`,
+                fieldOrInit.range
+            );
+            classContext.instanceInitializer.push(injectSnippet);
+        }
     }
 
 

--- a/src/compiler/java/language/JavaCompilerMessages.ts
+++ b/src/compiler/java/language/JavaCompilerMessages.ts
@@ -1148,4 +1148,70 @@ export class JCM {
         "fr": `Remplacez ${toReplace} par ${replaceBy}.`,
     })
 
+    /**
+     * Dependency Injection (@Instance / @Inject)
+     */
+    static diAnnotationRequiresParameter = (identifier: string) => le({
+        "id": "diAnnotationRequiresParameter",
+        "de": `Die Annotation @${identifier} benötigt einen Parameter (z.B. @${identifier}("meinName")).`,
+        "en": `Annotation @${identifier} requires a parameter (e.g. @${identifier}("myName")).`,
+        "fr": `L'annotation @${identifier} nécessite un paramètre (ex. @${identifier}("monNom")).`,
+    })
+
+    static diInstanceOnNonClass = () => le({
+        "id": "diInstanceOnNonClass",
+        "de": `@Instance darf nur auf Klassen angewendet werden, nicht auf Interfaces oder Enums.`,
+        "en": `@Instance can only be applied to classes, not to interfaces or enums.`,
+        "fr": `@Instance ne peut être appliqué qu'aux classes, pas aux interfaces ou aux enums.`,
+    })
+
+    static diInstanceOnAbstractClass = (name: string) => le({
+        "id": "diInstanceOnAbstractClass",
+        "de": `@Instance kann nicht auf die abstrakte Klasse '${name}' angewendet werden, da sie nicht instanziiert werden kann.`,
+        "en": `@Instance cannot be applied to abstract class '${name}' because it cannot be instantiated.`,
+        "fr": `@Instance ne peut pas être appliqué à la classe abstraite '${name}' car elle ne peut pas être instanciée.`,
+    })
+
+    static diInstanceOnMainClass = () => le({
+        "id": "diInstanceOnMainClass",
+        "de": `@Instance kann nicht auf die Hauptklasse angewendet werden.`,
+        "en": `@Instance cannot be applied to the main class.`,
+        "fr": `@Instance ne peut pas être appliqué à la classe principale.`,
+    })
+
+    static diDuplicateInstanceName = (name: string) => le({
+        "id": "diDuplicateInstanceName",
+        "de": `Der Instanzname '${name}' wird bereits von einer anderen Klasse verwendet.`,
+        "en": `The instance name '${name}' is already used by another class.`,
+        "fr": `Le nom d'instance '${name}' est déjà utilisé par une autre classe.`,
+    })
+
+    static diInstanceNoDefaultConstructor = (className: string) => le({
+        "id": "diInstanceNoDefaultConstructor",
+        "de": `Die Klasse '${className}' hat keinen zugänglichen parameterlosen Konstruktor und kann daher nicht als @Instance verwendet werden.`,
+        "en": `Class '${className}' has no accessible no-argument constructor and therefore cannot be used as @Instance.`,
+        "fr": `La classe '${className}' n'a pas de constructeur sans paramètres accessible et ne peut donc pas être utilisée comme @Instance.`,
+    })
+
+    static diInjectOnStaticField = () => le({
+        "id": "diInjectOnStaticField",
+        "de": `@Inject darf nicht auf statischen Feldern verwendet werden.`,
+        "en": `@Inject must not be used on static fields.`,
+        "fr": `@Inject ne doit pas être utilisé sur des champs statiques.`,
+    })
+
+    static diInjectUnknownName = (name: string) => le({
+        "id": "diInjectUnknownName",
+        "de": `Es gibt keine @Instance("${name}")-Klasse. Bitte überprüfe den Namen oder füge @Instance("${name}") zu einer Klasse hinzu.`,
+        "en": `There is no @Instance("${name}") class. Please check the name or add @Instance("${name}") to a class.`,
+        "fr": `Il n'y a pas de classe @Instance("${name}"). Vérifiez le nom ou ajoutez @Instance("${name}") à une classe.`,
+    })
+
+    static diCircularDependency = (cycle: string) => le({
+        "id": "diCircularDependency",
+        "de": `Zirkuläre @Inject-Abhängigkeit erkannt: ${cycle}. Bitte entferne die zirkuläre Abhängigkeit.`,
+        "en": `Circular @Inject dependency detected: ${cycle}. Please remove the circular dependency.`,
+        "fr": `Dépendance circulaire @Inject détectée: ${cycle}. Veuillez supprimer la dépendance circulaire.`,
+    })
+
 }

--- a/src/compiler/java/parser/AST.ts
+++ b/src/compiler/java/parser/AST.ts
@@ -540,4 +540,5 @@ export interface ASTTryCatchNode extends ASTStatementNode {
 export interface ASTAnnotationNode extends ASTStatementNode {
     kind: TokenType.annotation;
     identifier: string;
+    parameter?: string;
 }

--- a/src/compiler/java/parser/ASTNodeFactory.ts
+++ b/src/compiler/java/parser/ASTNodeFactory.ts
@@ -698,11 +698,12 @@ export class ASTNodeFactory {
         }
     }
 
-    buildAnnotationNode(identifer: Token): ASTAnnotationNode {
+    buildAnnotationNode(identifer: Token, parameter?: string): ASTAnnotationNode {
         return {
             kind: TokenType.annotation,
             range: identifer.range,
-            identifier: <string>identifer.value
+            identifier: <string>identifer.value,
+            parameter: parameter
         }
     }
 

--- a/src/compiler/java/parser/Parser.ts
+++ b/src/compiler/java/parser/Parser.ts
@@ -676,7 +676,15 @@ export class Parser extends StatementParser {
         if (this.comesToken(TokenType.at, true)) {
             let identifier = this.expectAndSkipIdentifierAsToken();
             if (identifier) {
-                this.collectedAnnotations.push(this.nodeFactory.buildAnnotationNode(identifier));
+                let parameter: string | undefined;
+                if (this.comesToken(TokenType.leftBracket, true)) {
+                    if (this.comesToken(TokenType.stringLiteral, false)) {
+                        parameter = String(this.cct.value);
+                        this.nextToken();
+                    }
+                    this.expect(TokenType.rightBracket, true);
+                }
+                this.collectedAnnotations.push(this.nodeFactory.buildAnnotationNode(identifier, parameter));
                 return identifier;
             }
         }

--- a/src/compiler/java/types/JavaAnnotation.ts
+++ b/src/compiler/java/types/JavaAnnotation.ts
@@ -4,7 +4,7 @@ import { IRange } from "../../common/range/Range";
 
 export class JavaAnnotation {
 
-    constructor(public identifier: string, public range: IRange){
+    constructor(public identifier: string, public range: IRange, public parameter?: string){
 
     }
 

--- a/src/compiler/java/types/JavaAnnotations.ts
+++ b/src/compiler/java/types/JavaAnnotations.ts
@@ -1,11 +1,12 @@
 import { lm } from "../../../tools/language/LanguageManager";
 
-type JavaAnnotationType = { 
+type JavaAnnotationType = {
     identifier: string;
     description: string;
     beforeClass: boolean;
     beforeMethod: boolean;
     beforeMethodOfMainClass: boolean;
+    beforeField: boolean;
 }
 
 class AnnotationDescriptions {
@@ -14,16 +15,26 @@ class AnnotationDescriptions {
         'en': `Indicates that the annotated method or all methods of the annotated class should be executed in full speed mode, ignoring any speed settings.`
     });
 
-    static override = () => lm({    
+    static override = () => lm({
         'de': `Zeigt an, dass eine Methode eine Methode in einer Superklasse überschreiben soll.`,
         'en': `Indicates that a method is intended to override a method in a superclass.`
     });
 
-    static test = () => lm({    
+    static test = () => lm({
         'de': `Zeigt an, dass eine Methode eine Testmethode ist oder eine Klasse Testmethoden enthält.`,
         'en': `Indicates that a method is a test method or that a class contains test methods.`
     });
-    
+
+    static instance = () => lm({
+        'de': `Erzeugt eine globale Singleton-Instanz dieser Klasse unter dem angegebenen Namen. Beispiel: @Instance("meinSpeicher")`,
+        'en': `Creates a global singleton instance of this class under the given name. Example: @Instance("myStorage")`
+    });
+
+    static inject = () => lm({
+        'de': `Injiziert die globale Instanz mit dem angegebenen Namen in dieses Feld. Beispiel: @Inject("meinSpeicher")`,
+        'en': `Injects the global instance with the given name into this field. Example: @Inject("myStorage")`
+    });
+
 }
 
 export var JavaAnnotations = {
@@ -32,21 +43,40 @@ export var JavaAnnotations = {
         description: AnnotationDescriptions.fullspeed(),
         beforeClass: true,
         beforeMethod: true,
-        beforeMethodOfMainClass: true  
+        beforeMethodOfMainClass: true,
+        beforeField: false
     },
     "Override": {
         identifier: "Override",
         description: AnnotationDescriptions.override(),
         beforeClass: false,
         beforeMethod: true,
-        beforeMethodOfMainClass: false
+        beforeMethodOfMainClass: false,
+        beforeField: false
     },
     "Test": {
         identifier: "Test",
         description: AnnotationDescriptions.test(),
         beforeClass: true,
         beforeMethod: true,
-        beforeMethodOfMainClass: true
+        beforeMethodOfMainClass: true,
+        beforeField: false
+    },
+    "Instance": {
+        identifier: "Instance",
+        description: AnnotationDescriptions.instance(),
+        beforeClass: true,
+        beforeMethod: false,
+        beforeMethodOfMainClass: false,
+        beforeField: false
+    },
+    "Inject": {
+        identifier: "Inject",
+        description: AnnotationDescriptions.inject(),
+        beforeClass: false,
+        beforeMethod: false,
+        beforeMethodOfMainClass: false,
+        beforeField: true
     }
 };
 

--- a/src/compiler/java/types/NonPrimitiveType.ts
+++ b/src/compiler/java/types/NonPrimitiveType.ts
@@ -89,6 +89,9 @@ export abstract class NonPrimitiveType extends JavaType implements BaseObjectTyp
 
     staticInitializer?: Program;
 
+    diInstanceName?: string;
+    diInitializer?: Program;
+
     staticConstructorsDependOn: Map<NonPrimitiveType, boolean> = new Map();
 
     public pathAndIdentifier: string;

--- a/src/test/java/DependencyInjectionTest.java
+++ b/src/test/java/DependencyInjectionTest.java
@@ -1,0 +1,186 @@
+/**::
+ * Basic @Instance/@Inject: shared singleton between two classes
+ */
+@Instance("counter")
+class Counter {
+    int value = 0;
+    void increment() { value++; }
+    int getValue() { return value; }
+}
+
+class ClassA {
+    @Inject("counter")
+    Counter c;
+    void inc() { c.increment(); }
+}
+
+class ClassB {
+    @Inject("counter")
+    Counter c;
+    int get() { return c.getValue(); }
+}
+
+ClassA a = new ClassA();
+ClassB b = new ClassB();
+a.inc();
+a.inc();
+assertEquals(2, b.get(), "Shared @Instance singleton: ClassA and ClassB should see the same Counter");
+
+
+/**::
+ * @Inject in multiple instances of the same class share the singleton
+ */
+@Instance("shared")
+class SharedData {
+    int x = 0;
+}
+
+class User {
+    @Inject("shared")
+    SharedData data;
+    void set(int v) { data.x = v; }
+    int get() { return data.x; }
+}
+
+User u1 = new User();
+User u2 = new User();
+u1.set(42);
+assertEquals(42, u2.get(), "Multiple instances of the same class should share the @Instance singleton");
+
+
+/**::
+ * @Instance class with non-primitive field
+ */
+@Instance("store")
+class DataStore {
+    ArrayList<String> items = new ArrayList<>();
+    void add(String s) { items.add(s); }
+    int size() { return items.size(); }
+}
+
+class Writer {
+    @Inject("store")
+    DataStore ds;
+    void write(String s) { ds.add(s); }
+}
+
+class Reader {
+    @Inject("store")
+    DataStore ds;
+    int count() { return ds.size(); }
+}
+
+Writer w = new Writer();
+Reader r = new Reader();
+w.write("hello");
+w.write("world");
+assertEquals(2, r.count(), "@Instance with ArrayList: writes by Writer visible through Reader");
+
+
+/**::
+ * Error: @Instance on an interface
+ * { "expectedCompilationError": {"id": "diInstanceOnNonClass"} }
+ */
+@Instance("diTestFoo")
+interface DiTestFoo {}
+
+
+/**::
+ * Error: @Instance on an enum
+ * { "expectedCompilationError": {"id": "diInstanceOnNonClass"} }
+ */
+@Instance("diTestColor")
+enum DiTestColor { RED, GREEN, BLUE }
+
+
+/**::
+ * Error: @Instance on an abstract class
+ * { "expectedCompilationError": {"id": "diInstanceOnAbstractClass"} }
+ */
+@Instance("diTestShape")
+abstract class DiTestShape {
+    abstract void draw();
+}
+
+
+/**::
+ * Error: duplicate @Instance name
+ * { "expectedCompilationError": {"id": "diDuplicateInstanceName"} }
+ */
+@Instance("service")
+class ServiceA {}
+
+@Instance("service")
+class ServiceB {}
+
+
+/**::
+ * Error: @Instance class has no default constructor
+ * { "expectedCompilationError": {"id": "diInstanceNoDefaultConstructor"} }
+ */
+@Instance("thing")
+class Thing {
+    int value;
+    Thing(int v) { value = v; }
+}
+
+
+/**::
+ * Error: @Inject on a static field
+ * { "expectedCompilationError": {"id": "diInjectOnStaticField"} }
+ */
+@Instance("repo")
+class Repo {}
+
+class Service {
+    @Inject("repo")
+    static Repo r;
+}
+
+
+/**::
+ * Error: @Inject references unknown instance name
+ * { "expectedCompilationError": {"id": "diInjectUnknownName"} }
+ */
+class Client {
+    @Inject("missing")
+    Object obj;
+}
+
+
+/**::
+ * Error: circular dependency between two @Instance classes
+ * { "expectedCompilationError": {"id": "diCircularDependency"} }
+ */
+@Instance("alpha")
+class Alpha {
+    @Inject("beta")
+    Beta b;
+}
+
+@Instance("beta")
+class Beta {
+    @Inject("alpha")
+    Alpha a;
+}
+
+
+/**::
+ * Error: @Instance used without a parameter
+ * { "expectedCompilationError": {"id": "diAnnotationRequiresParameter"} }
+ */
+@Instance
+class NoName {}
+
+
+/**::
+ * Error: @Inject used without a parameter
+ * { "expectedCompilationError": {"id": "diAnnotationRequiresParameter"} }
+ */
+@Instance("source")
+class Source {}
+
+class Sink {
+    @Inject
+    Source s;
+}


### PR DESCRIPTION
Dieses Feature wäre für mein Schulprojekt und meine Gruppe wirklich hilfreich, da wir damit gemeinsam genutzte Datenspeicher zwischen Klassen einfach und sauber realisieren können, ohne globale Variablen oder manuelle Weitergabe von Objektreferenzen.

### Was wurde hinzugefügt?
Zwei neue Annotationen ermöglichen ein einfaches Dependency-Injection-System:

```
@Instance("name") — Platziert über einer Klasse. Erzeugt beim Programmstart automatisch eine globale Singleton-Instanz dieser Klasse unter dem angegebenen Namen.
@Inject("name") — Platziert über einem Feld. Injiziert die benannte Singleton-Instanz in dieses Feld bei jeder Objekterzeugung.
Beispiel:


@Instance("storage")
class DataStorage {
    int count = 0;
}

class ClassA {
    @Inject("storage")
    DataStorage ds;
    void increment() { ds.count++; }
}

class ClassB {
    @Inject("storage")
    DataStorage ds;
    void print() { System.out.println(ds.count); }
}

new ClassA().increment();
new ClassB().print(); // gibt 1 aus — beide sehen dieselbe Instanz
```