### PR TITLE
Add Relative Mouse Movement with Pointer Lock support for Actor

### DIFF
--- a/src/compiler/java/language/JavaRuntimeLibraryComments.ts
+++ b/src/compiler/java/language/JavaRuntimeLibraryComments.ts
@@ -467,6 +467,21 @@ export class JRC {
         "en": `Returns value of Gamepad-stick with given index on given axis.`,
     })
 
+    static actorOnMouseMovementComment = () => lm({
+        "de": "Wird aufgerufen, wenn der Mauszeiger gesperrt ist (enablePointerLock) und sich die Maus bewegt. dx und dy sind die relative Bewegung in Pixeln.",
+        "en": "Called when the mouse pointer is locked (enablePointerLock) and the mouse moves. dx and dy are the relative movement in pixels.",
+    })
+
+    static actorEnablePointerLockComment = () => lm({
+        "de": "Sperrt den Mauszeiger in die Canvas (Pointer Lock). Danach wird onMouseMovement mit der relativen Mausbewegung aufgerufen.",
+        "en": "Locks the mouse pointer to the canvas (Pointer Lock). Afterwards onMouseMovement is called with relative mouse movement.",
+    })
+
+    static actorDisablePointerLockComment = () => lm({
+        "de": "Gibt den gesperrten Mauszeiger wieder frei.",
+        "en": "Releases the locked mouse pointer.",
+    })
+
     /**
      * class World3d
     */

--- a/src/compiler/java/runtime/graphics/ActorClass.ts
+++ b/src/compiler/java/runtime/graphics/ActorClass.ts
@@ -13,6 +13,7 @@ import { ActorManager } from "./ActorManager";
 import { IActor } from "./IActor";
 import { IWorld } from "./IWorld";
 
+
 // TODO: Gamepad support
 /**
  * Base class of all Objects which have an act-method and kan sense keyboard or gamepad
@@ -40,6 +41,10 @@ export class ActorClass extends ObjectClass implements IActor {
         { type: "method", signature: "final double getGamepadAxisValue(int gamepadIndex, int axisIndex)", native: ActorClass.prototype._getGamepadAxisValue, comment: JRC.actorGetGamepadAxisValueComment },
 
         {type: "method", signature: "static void setActFrequency(int frequencyInHz)", java: ActorClass._mj$setCallActMethodFrequency$void$int$, comment: JRC.SystemToolsSetCallActMethodFrequency},
+
+        { type: "method", signature: "void onMouseMovement(double dx, double dy)", java: ActorClass.prototype._mj$onMouseMovement$void$double$double, comment: JRC.actorOnMouseMovementComment },
+        { type: "method", signature: "final void enablePointerLock()", java: ActorClass.prototype._mj$enablePointerLock$void$, comment: JRC.actorEnablePointerLockComment },
+        { type: "method", signature: "final void disablePointerLock()", java: ActorClass.prototype._mj$disablePointerLock$void$, comment: JRC.actorDisablePointerLockComment },
 
     ]
 
@@ -84,6 +89,10 @@ export class ActorClass extends ObjectClass implements IActor {
             this.actorManager.registerActor(this, "keyUp");
         }
 
+        if (this._mj$onMouseMovement$void$double$double != ActorClass.prototype._mj$onMouseMovement$void$double$double) {
+            this.actorManager.registerActor(this, "mouseMovement");
+        }
+
     }
 
     
@@ -111,7 +120,22 @@ export class ActorClass extends ObjectClass implements IActor {
     
     _mj$onKeyDown$void$String(t: Thread, callback: CallbackParameter, key: StringClass): void {
     }
-    
+
+    _mj$onMouseMovement$void$double$double(t: Thread, callback: CallbackParameter, dx: number, dy: number): void {
+    }
+
+    _mj$enablePointerLock$void$(t: Thread, callback: CallbackParameter): void {
+        let world = t.scheduler.interpreter.retrieveObject("WorldClass") as IWorld;
+        world?.mouseManager.enablePointerLock();
+        if (callback) callback();
+    }
+
+    _mj$disablePointerLock$void$(t: Thread, callback: CallbackParameter): void {
+        let world = t.scheduler.interpreter.retrieveObject("WorldClass") as IWorld;
+        world?.mouseManager.disablePointerLock();
+        if (callback) callback();
+    }
+
     _mj$destroy$void$(t: Thread) {
         this.destroy();
     }

--- a/src/compiler/java/runtime/graphics/ActorManager.ts
+++ b/src/compiler/java/runtime/graphics/ActorManager.ts
@@ -19,7 +19,8 @@ export class ActorManager {
         "actWithTime": [],
         "keyDown": [],
         "keyUp": [],
-        "keyPressed": []
+        "keyPressed": [],
+        "mouseMovement": []
     };
 
     keyDownListener: KeyDownListener = (key: string, isShift: boolean, isCtrl: boolean, isAlt: boolean) => {
@@ -181,5 +182,15 @@ export class ActorManager {
         }
         t.state = ThreadState.running;
 
+    }
+
+    onMouseMovement(dx: number, dy: number): void {
+        if (this.actors["mouseMovement"].length == 0) return;
+        let t = this.interpreter.scheduler.createThread("mouse movement event thread");
+
+        for (let actor of this.actors["mouseMovement"]) {
+            if (actor.isActing) actor._mj$onMouseMovement$void$double$double(t, undefined, dx, dy);
+        }
+        t.state = ThreadState.running;
     }
 }

--- a/src/compiler/java/runtime/graphics/IActor.ts
+++ b/src/compiler/java/runtime/graphics/IActor.ts
@@ -1,7 +1,7 @@
 import { Thread } from "../../../common/interpreter/Thread";
 import { StringClass } from "../system/javalang/ObjectClassStringClass";
 
-export const ActorTypes = ["act", "actWithTime", "keyPressed", "keyUp", "keyDown"] as const;
+export const ActorTypes = ["act", "actWithTime", "keyPressed", "keyUp", "keyDown", "mouseMovement"] as const;
 export type ActorType = typeof ActorTypes[number];
 
 export interface IActor {
@@ -12,4 +12,5 @@ export interface IActor {
     _mj$onKeyUp$void$String(t: Thread, callback: (() => {}) | undefined, key: StringClass): void;
     _mj$onKeyDown$void$String(t: Thread, callback: (() => {}) | undefined,
         key: StringClass): void;
+    _mj$onMouseMovement$void$double$double(t: Thread, callback: (() => {}) | undefined, dx: number, dy: number): void;
 }

--- a/src/compiler/java/runtime/graphics/MouseManager2D.ts
+++ b/src/compiler/java/runtime/graphics/MouseManager2D.ts
@@ -22,10 +22,16 @@ export class MouseManager {
 
     listeners: Map<string, any> = new Map();
 
+    isPointerLocked: boolean = false;
+    private pointerLockChangeListener: () => void = () => {};
+    private pointerLockErrorListener: () => void = () => {};
+
     constructor(private world: IWorld, private coordinateDiv: HTMLDivElement) {
     }
 
     unregisterListeners(){
+        this.disablePointerLock();
+
         let canvas = this.world.app!.canvas;
         for (let mouseEventKind of ["mouseup", "mousedown", "mousemove", "mouseenter", "mouseleave"]) {
             canvas.removeEventListener(mouseEventKind, this.listeners.get(mouseEventKind));
@@ -90,6 +96,10 @@ export class MouseManager {
                 if(this.coordinateDiv  && mouseEventKind == "mousemove") this.coordinateDiv.textContent = '(' + Math.round(x) + "/" + Math.round(y) + ")";
                 if(this.coordinateDiv  && mouseEventKind == "mouseleave") this.coordinateDiv.textContent = '';
 
+                if (mouseEventKind === "mousemove" && this.isPointerLocked) {
+                    this.world.interpreter.actorManager.onMouseMovement(e.movementX, e.movementY);
+                }
+
                 // if (listenerType == "mousedown") {
                 //     let gngEreignisbehandlung = this.interpreter.gngEreignisbehandlungHelper;
                 //     if (gngEreignisbehandlung != null) {
@@ -124,6 +134,30 @@ export class MouseManager {
         this.shapesWithImplementedMouseMethods = [];
         this.internalMouseListeners = [];
         this.listeners = new Map();
+    }
+
+    enablePointerLock(): void {
+        let canvas = this.world.app!.canvas;
+
+        this.pointerLockChangeListener = () => {
+            this.isPointerLocked = document.pointerLockElement === canvas;
+        };
+        this.pointerLockErrorListener = () => {
+            this.isPointerLocked = false;
+        };
+
+        document.addEventListener("pointerlockchange", this.pointerLockChangeListener);
+        document.addEventListener("pointerlockerror", this.pointerLockErrorListener);
+        canvas.requestPointerLock();
+    }
+
+    disablePointerLock(): void {
+        if (this.isPointerLocked) {
+            document.exitPointerLock();
+        }
+        this.isPointerLocked = false;
+        document.removeEventListener("pointerlockchange", this.pointerLockChangeListener);
+        document.removeEventListener("pointerlockerror", this.pointerLockErrorListener);
     }
 
     addShapeWithImplementedMouseMethods(shape: ShapeClass) {

--- a/src/test/ActorPointerLock.test.ts
+++ b/src/test/ActorPointerLock.test.ts
@@ -1,0 +1,167 @@
+import { expect, test, vi, beforeEach, afterEach } from 'vitest';
+import { ActorTypes } from '../compiler/java/runtime/graphics/IActor';
+import { MouseManager } from '../compiler/java/runtime/graphics/MouseManager2D';
+import { ActorManager } from '../compiler/java/runtime/graphics/ActorManager';
+import { ThreadState } from '../compiler/common/interpreter/ThreadState';
+
+// --- IActor ---
+
+test('ActorTypes includes mouseMovement', () => {
+    expect(ActorTypes).toContain('mouseMovement');
+});
+
+// --- ActorManager ---
+
+function makeActorManager() {
+    const mockThread = { state: ThreadState.suspended, programStack: [] as any[] };
+    const mockInterpreter = {
+        keyboardManager: undefined,
+        scheduler: { createThread: vi.fn().mockReturnValue(mockThread) },
+        eventManager: { on: vi.fn() },
+    } as any;
+    return { actorManager: new ActorManager(mockInterpreter), mockThread, mockInterpreter };
+}
+
+test('ActorManager.onMouseMovement dispatches dx and dy to registered actors', () => {
+    const { actorManager, mockThread } = makeActorManager();
+    const mockActor = { isActing: true, _mj$onMouseMovement$void$double$double: vi.fn() } as any;
+
+    actorManager.registerActor(mockActor, 'mouseMovement');
+    actorManager.onMouseMovement(5, 10);
+
+    expect(mockActor._mj$onMouseMovement$void$double$double).toHaveBeenCalledWith(mockThread, undefined, 5, 10);
+    expect(mockThread.state).toBe(ThreadState.running);
+});
+
+test('ActorManager.onMouseMovement skips actors with isActing = false', () => {
+    const { actorManager } = makeActorManager();
+    const inactiveActor = { isActing: false, _mj$onMouseMovement$void$double$double: vi.fn() } as any;
+
+    actorManager.registerActor(inactiveActor, 'mouseMovement');
+    actorManager.onMouseMovement(3, 7);
+
+    expect(inactiveActor._mj$onMouseMovement$void$double$double).not.toHaveBeenCalled();
+});
+
+test('ActorManager.onMouseMovement does nothing when no mouseMovement actors registered', () => {
+    const { actorManager, mockInterpreter } = makeActorManager();
+
+    actorManager.onMouseMovement(1, 2);
+
+    expect(mockInterpreter.scheduler.createThread).not.toHaveBeenCalled();
+});
+
+test('ActorManager.onMouseMovement dispatches to all registered actors', () => {
+    const { actorManager } = makeActorManager();
+    const actor1 = { isActing: true, _mj$onMouseMovement$void$double$double: vi.fn() } as any;
+    const actor2 = { isActing: true, _mj$onMouseMovement$void$double$double: vi.fn() } as any;
+
+    actorManager.registerActor(actor1, 'mouseMovement');
+    actorManager.registerActor(actor2, 'mouseMovement');
+    actorManager.onMouseMovement(-2, 8);
+
+    expect(actor1._mj$onMouseMovement$void$double$double).toHaveBeenCalledOnce();
+    expect(actor2._mj$onMouseMovement$void$double$double).toHaveBeenCalledOnce();
+});
+
+// --- MouseManager ---
+
+function makeMouseManager() {
+    const canvas = { requestPointerLock: vi.fn() } as any;
+    const mockActorManager = { onMouseMovement: vi.fn() };
+    const mockWorld = {
+        app: { canvas },
+        interpreter: { actorManager: mockActorManager },
+    } as any;
+    return { mouseManager: new MouseManager(mockWorld, null as any), canvas, mockActorManager };
+}
+
+beforeEach(() => {
+    vi.spyOn(document, 'addEventListener');
+    vi.spyOn(document, 'removeEventListener');
+    Object.defineProperty(document, 'exitPointerLock', {
+        value: vi.fn(),
+        writable: true,
+        configurable: true,
+    });
+});
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+test('MouseManager.enablePointerLock calls canvas.requestPointerLock', () => {
+    const { mouseManager, canvas } = makeMouseManager();
+    mouseManager.enablePointerLock();
+    expect(canvas.requestPointerLock).toHaveBeenCalledOnce();
+});
+
+test('MouseManager.enablePointerLock registers pointerlockchange and pointerlockerror on document', () => {
+    const { mouseManager } = makeMouseManager();
+    mouseManager.enablePointerLock();
+    expect(document.addEventListener).toHaveBeenCalledWith('pointerlockchange', expect.any(Function));
+    expect(document.addEventListener).toHaveBeenCalledWith('pointerlockerror', expect.any(Function));
+});
+
+test('pointerlockchange handler sets isPointerLocked = true when canvas is lock element', () => {
+    const { mouseManager, canvas } = makeMouseManager();
+    mouseManager.enablePointerLock();
+
+    const [, handler] = (document.addEventListener as any).mock.calls.find(
+        ([event]: [string]) => event === 'pointerlockchange'
+    );
+
+    Object.defineProperty(document, 'pointerLockElement', { value: canvas, configurable: true });
+    handler();
+    expect(mouseManager.isPointerLocked).toBe(true);
+});
+
+test('pointerlockchange handler sets isPointerLocked = false when canvas is not the lock element', () => {
+    const { mouseManager } = makeMouseManager();
+    mouseManager.isPointerLocked = true;
+    mouseManager.enablePointerLock();
+
+    const [, handler] = (document.addEventListener as any).mock.calls.find(
+        ([event]: [string]) => event === 'pointerlockchange'
+    );
+
+    Object.defineProperty(document, 'pointerLockElement', { value: null, configurable: true });
+    handler();
+    expect(mouseManager.isPointerLocked).toBe(false);
+});
+
+test('pointerlockerror handler sets isPointerLocked = false', () => {
+    const { mouseManager } = makeMouseManager();
+    mouseManager.isPointerLocked = true;
+    mouseManager.enablePointerLock();
+
+    const [, handler] = (document.addEventListener as any).mock.calls.find(
+        ([event]: [string]) => event === 'pointerlockerror'
+    );
+    handler();
+    expect(mouseManager.isPointerLocked).toBe(false);
+});
+
+test('MouseManager.disablePointerLock calls exitPointerLock when pointer is locked', () => {
+    const { mouseManager } = makeMouseManager();
+    mouseManager.isPointerLocked = true;
+    mouseManager.disablePointerLock();
+    expect(document.exitPointerLock).toHaveBeenCalledOnce();
+    expect(mouseManager.isPointerLocked).toBe(false);
+});
+
+test('MouseManager.disablePointerLock does not call exitPointerLock when not locked', () => {
+    const { mouseManager } = makeMouseManager();
+    mouseManager.isPointerLocked = false;
+    mouseManager.disablePointerLock();
+    expect(document.exitPointerLock).not.toHaveBeenCalled();
+});
+
+test('MouseManager.disablePointerLock removes document listeners', () => {
+    const { mouseManager } = makeMouseManager();
+    mouseManager.enablePointerLock();
+    mouseManager.isPointerLocked = false;
+    mouseManager.disablePointerLock();
+    expect(document.removeEventListener).toHaveBeenCalledWith('pointerlockchange', expect.any(Function));
+    expect(document.removeEventListener).toHaveBeenCalledWith('pointerlockerror', expect.any(Function));
+});

--- a/src/test/java/ActorPointerLockTest.java
+++ b/src/test/java/ActorPointerLockTest.java
@@ -1,0 +1,93 @@
+/**::
+ * Actor with onMouseMovement override compiles and instantiates correctly
+ */
+class MovementActor extends Actor {
+    double lastDx = 0;
+    double lastDy = 0;
+
+    void onMouseMovement(double dx, double dy) {
+        lastDx = dx;
+        lastDy = dy;
+    }
+}
+
+MovementActor actor = new MovementActor();
+assertTrue(!actor.isDestroyed(), "MovementActor should not be destroyed after instantiation");
+
+
+/**::
+ * onMouseMovement stores the received dx and dy values
+ */
+class TrackingActor extends Actor {
+    double receivedDx = 0;
+    double receivedDy = 0;
+    int callCount = 0;
+
+    void onMouseMovement(double dx, double dy) {
+        receivedDx = dx;
+        receivedDy = dy;
+        callCount++;
+    }
+}
+
+TrackingActor ta = new TrackingActor();
+ta.onMouseMovement(5.0, -3.0);
+assertEquals(5.0, ta.receivedDx, "onMouseMovement should store dx correctly");
+assertEquals(-3.0, ta.receivedDy, "onMouseMovement should store dy correctly");
+assertEquals(1, ta.callCount, "onMouseMovement should have been called once");
+
+ta.onMouseMovement(-12.5, 7.25);
+assertEquals(-12.5, ta.receivedDx, "onMouseMovement should update dx on second call");
+assertEquals(7.25, ta.receivedDy, "onMouseMovement should update dy on second call");
+assertEquals(2, ta.callCount, "onMouseMovement should have been called twice");
+
+
+/**::
+ * enablePointerLock and disablePointerLock compile and run without crashing
+ */
+class LockTestActor extends Actor {
+    void testLock() {
+        enablePointerLock();
+        disablePointerLock();
+    }
+}
+
+LockTestActor la = new LockTestActor();
+la.testLock();
+assertTrue(!la.isDestroyed(), "Actor should remain valid after calling enablePointerLock/disablePointerLock");
+
+
+/**::
+ * Actor without onMouseMovement override does not crash on instantiation
+ */
+class PlainActor extends Actor {
+    void act() {}
+}
+
+PlainActor pa = new PlainActor();
+assertTrue(!pa.isDestroyed(), "PlainActor without onMouseMovement should instantiate fine");
+
+
+/**::
+ * Multiple Actor instances with onMouseMovement track their own state independently
+ */
+class IndependentActor extends Actor {
+    double dx = 0;
+    double dy = 0;
+
+    void onMouseMovement(double dx, double dy) {
+        this.dx = dx;
+        this.dy = dy;
+    }
+}
+
+IndependentActor a1 = new IndependentActor();
+IndependentActor a2 = new IndependentActor();
+
+a1.onMouseMovement(10.0, 20.0);
+a2.onMouseMovement(-5.0, 3.0);
+
+assertEquals(10.0, a1.dx, "a1.dx should be 10");
+assertEquals(20.0, a1.dy, "a1.dy should be 20");
+assertEquals(-5.0, a2.dx, "a2.dx should be -5");
+assertEquals(3.0, a2.dy, "a2.dy should be 3");


### PR DESCRIPTION
Hallo Herr Pabst,
wir sind bei unserem 3D Spiel leider auf ein weiteres Problem gestoßen. Diese Änderung sollte das Problem beheben. Ich hoffe sie können dieses Feature ebenfalls in die Online-IDE übernehmen. Bei fragen können sie sich gerne an mich wenden. Mein bisheriger Test Code war der Folgende:
```
class TestActor extends Actor {

    void onKeyDown(String key) {
        if (key.equals(" ")) {
            enablePointerLock();
        }
    }

    void onMouseMovement(double dx, double dy) {
        println("dx=" + dx + "  dy=" + dy);
    }
}

World w = new World();
TestActor a = new TestActor();
```

Problembeschreibung:
Das bisherige System erlaubt es Actors zwar, auf Maus-Events wie Hover, Klick oder absolute Mausposition zu reagieren, bietet aber keine Möglichkeit, relative Mausbewegung zu messen. Ohne Pointer Lock stößt die Maus an den Canvas-Rand und lässt sich nicht weiterbewegen — ein grundlegendes Problem für alle Anwendungen, die eine freie, unbegrenzte Maussteuerung benötigen (FPS-Steuerung, 3D-Kamera, Drag-Rotation etc.).
