### PR TITLE
Add devcontainer configuration for Online IDE

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,27 @@
+﻿{
+  "name": "Online IDE",
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:1-22-bookworm",
+
+  "forwardPorts": [3000],
+  "portsAttributes": {
+    "3000": {
+      "label": "Vite Dev Server",
+      "onAutoForward": "openBrowser"
+    }
+  },
+
+  "postCreateCommand": "npm install",
+
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "dbaeumer.vscode-eslint",
+        "esbenp.prettier-vscode"
+      ],
+      "settings": {
+        "editor.formatOnSave": true,
+        "js/ts.tsdk.path": "node_modules/typescript/lib"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Hallo Herr Pabst,
als ich meine Änderungen an der Online-IDE vorgenommen habe, habe ich mir dafür eine Devcontainer-Config angelegt. Ich bin ein Fan davon, meine Entwicklungsumgebung nicht direkt auf meinem Computer zu installieren, sondern diese je nach Projekt schnell aufsetzen und von meinem Hauptsystem separiert halten zu können. Ich dachte mir, ich reiche die Config einfach mal ein, damit andere es in Zukunft leichter haben, etwas zum Gesamtprojekt beizusteuern bzw. das Projekt schneller bei sich zum Laufen zu bringen.